### PR TITLE
Fix theme blurring on Linux.

### DIFF
--- a/themes/dracula.json
+++ b/themes/dracula.json
@@ -7,6 +7,7 @@
       "name": "Dracula",
       "appearance": "dark",
       "style": {
+        "background.appearance": "blurred",
         "border": "#3c324bcc",
         "border.variant": "#C9A8F933",
         "border.focused": "#C9A8F977",


### PR DESCRIPTION
Fixes blurring on Wayland.

I don't think it's possible to fix blurring on X11, but that's for the Zed team.

Resolves #16 