### PR TITLE
Fix typo in Dracula Light theme name

### DIFF
--- a/themes/dracula.json
+++ b/themes/dracula.json
@@ -827,7 +827,7 @@
       }
     },
     {
-      "name": "Dracula Light (Alucard",
+      "name": "Dracula Light (Alucard)",
       "appearance": "light",
       "style": {
         "accents": [


### PR DESCRIPTION
Super small change

The name for the light variant was missing a closing parenthesis.

Thanks for the theme!